### PR TITLE
Bugfix/browser router

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-boilerplate",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Boilerplate for starting a new react project.",
   "main": "public/index.html",
   "repository": "https://github.com/jfehrman/react-boilerplate.git",

--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {
-  BrowserRouter as Router,
+  HashRouter as Router,
   Switch,
   Route,
 } from 'react-router-dom'


### PR DESCRIPTION
Swapping browser router for hash router.  This allows us to hit re-usable urls without having to hit the base URL first and navigate to the pages using the menu.

resolves #38 